### PR TITLE
Redact api key PRO-484

### DIFF
--- a/src/server/trace_layer.rs
+++ b/src/server/trace_layer.rs
@@ -1,0 +1,25 @@
+use axum::extract::MatchedPath;
+use hyper::Request;
+use tower_http::trace::MakeSpan;
+use tracing::{Level, Span};
+
+/// MakeSpan to remove api keys from logs
+#[derive(Clone)]
+pub(crate) struct MatchedPathMakeSpan;
+
+impl<B> MakeSpan<B> for MatchedPathMakeSpan {
+    fn make_span(&mut self, request: &Request<B>) -> Span {
+        let matched_path = request
+            .extensions()
+            .get::<MatchedPath>()
+            .map(MatchedPath::as_str);
+
+        tracing::span!(
+            Level::DEBUG,
+            "request",
+            method = %request.method(),
+            matched_path,
+            version = ?request.version(),
+        )
+    }
+}


### PR DESCRIPTION
The default `TracingLayer` for `tower-http` creates tracing spans with uri fields. This was leaking our api keys into our logs. This fix creates a custom span with the matched path as a field rather than the plaintext uri.