### PR TITLE
fix: startup with pre-defined values.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -53,6 +53,7 @@ impl Database {
             r#"
             INSERT INTO relayers (id, name, chain_id, key_id, address)
             VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT DO NOTHING
         "#,
         )
         .bind(id)
@@ -969,6 +970,7 @@ impl Database {
             r#"
             INSERT INTO networks (chain_id, name)
             VALUES ($1, $2)
+            ON CONFLICT DO NOTHING
             "#,
         )
         .bind(chain_id as i64)
@@ -982,6 +984,7 @@ impl Database {
             VALUES
                 ($1, $2, $3),
                 ($1, $4, $5)
+            ON CONFLICT DO NOTHING
             "#,
         )
         .bind(chain_id as i64)
@@ -1043,6 +1046,7 @@ impl Database {
             r#"
             INSERT INTO api_keys (relayer_id, key_hash)
             VALUES ($1, $2)
+            ON CONFLICT DO NOTHING
             "#,
         )
         .bind(relayer_id)


### PR DESCRIPTION
When tx-sitter starts with pre-defined relayer in the config, it inserts records about it in the DB. When the tx-sitter restarts, it fails to insert the same record again with the following error message:

> Error: error returned from database: duplicate key value violates unique constraint "networks_pkey"
>
> Caused by:
>     duplicate key value violates unique constraint "networks_pkey"

After this commit if a conflicting record is detected, do nothing.