### PR TITLE
Change response on db conflict for transactions to 409 instead of 500.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -214,7 +214,7 @@ impl TxSitterClient {
 }
 
 impl ClientError {
-    pub fn tx_sitter_messager(&self) -> Option<&str> {
+    pub fn tx_sitter_message(&self) -> Option<&str> {
         match self {
             Self::TxSitter(_, s) => Some(s),
             _ => None,

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use ethers::types::{Address, H256, U256};
-use poem::http::StatusCode;
 use sqlx::migrate::{MigrateDatabase, Migrator};
 use sqlx::types::{BigDecimal, Json};
 use sqlx::{Pool, Postgres, Row};
@@ -31,7 +30,7 @@ pub struct Database {
 
 pub enum CreateResult {
     SUCCESS,
-    CONFLICT
+    CONFLICT,
 }
 
 impl Database {
@@ -323,12 +322,9 @@ impl Database {
         .execute(tx.as_mut())
         .await;
 
-        if let Err(ref err) = res {
-            if let sqlx::Error::Database(err) = err
-            {
-                if err.constraint() == Some("transactions_pkey") {
-                    return Ok(CreateResult::CONFLICT);
-                }
+        if let Err(sqlx::Error::Database(ref err)) = res {
+            if err.constraint() == Some("transactions_pkey") {
+                return Ok(CreateResult::CONFLICT);
             }
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -265,14 +265,11 @@ impl RelayerApi {
             )
             .await?;
 
-        match res {
-            CreateResult::CONFLICT => {
-                return Err(poem::error::Error::from_string(
-                    "Transaction with same id already exists.".to_string(),
-                    StatusCode::CONFLICT,
-                ));
-            }
-            _ => {}
+        if let CreateResult::CONFLICT = res {
+            return Err(poem::error::Error::from_string(
+                "Transaction with same id already exists.".to_string(),
+                StatusCode::CONFLICT,
+            ));
         }
 
         tracing::info!(tx_id, "Transaction created");

--- a/tests/send_too_many_txs.rs
+++ b/tests/send_too_many_txs.rs
@@ -83,7 +83,7 @@ async fn send_too_many_txs() -> eyre::Result<()> {
 
     // TODO: Fix checking errors by string
     assert_eq!(
-        result.as_ref().err().and_then(|e| e.tx_sitter_messager()),
+        result.as_ref().err().and_then(|e| e.tx_sitter_message()),
         Some("Relayer queue is full"),
         "Result {:?} should be too many transactions",
         result

--- a/tests/send_too_many_txs.rs
+++ b/tests/send_too_many_txs.rs
@@ -83,7 +83,7 @@ async fn send_too_many_txs() -> eyre::Result<()> {
 
     // TODO: Fix checking errors by string
     assert_eq!(
-        result.as_ref().err().and_then(|e| e.tx_sitter()),
+        result.as_ref().err().and_then(|e| e.tx_sitter_messager()),
         Some("Relayer queue is full"),
         "Result {:?} should be too many transactions",
         result

--- a/tests/send_tx_with_same_id.rs
+++ b/tests/send_tx_with_same_id.rs
@@ -1,0 +1,58 @@
+mod common;
+
+use reqwest::StatusCode;
+use tx_sitter::client::ClientError;
+
+use crate::common::prelude::*;
+
+#[tokio::test]
+async fn send_tx_with_same_id() -> eyre::Result<()> {
+    setup_tracing();
+
+    let (db_url, _db_container) = setup_db().await?;
+    let anvil = AnvilBuilder::default().spawn().await?;
+
+    let (_service, client) =
+        ServiceBuilder::default().build(&anvil, &db_url).await?;
+    let CreateApiKeyResponse { api_key } =
+        client.create_relayer_api_key(DEFAULT_RELAYER_ID).await?;
+
+    let tx_id = Some("tx-1".to_string());
+
+    // Send a transaction
+    let value: U256 = parse_units("1", "ether")?.into();
+    client
+        .send_tx(
+            &api_key,
+            &SendTxRequest {
+                to: ARBITRARY_ADDRESS.into(),
+                value: value.into(),
+                gas_limit: U256::from(21_000).into(),
+                tx_id: tx_id.clone(),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let res = client
+        .send_tx(
+            &api_key,
+            &SendTxRequest {
+                to: ARBITRARY_ADDRESS.into(),
+                value: value.into(),
+                gas_limit: U256::from(21_000).into(),
+                tx_id: tx_id.clone(),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    if let ClientError::TxSitter(status_code, message) = res.unwrap_err() {
+        assert_eq!(status_code, StatusCode::CONFLICT);
+        assert_eq!(message, "Transaction with same id already exists.");
+
+        return Ok(());
+    }
+
+    panic!("Should return error on second insert with same id.")
+}


### PR DESCRIPTION
The goal of this change is to return 409 status code (CONFLICT) when someone is trying to add transaction with id that is already in database. Now the response is 500 with message passed from DB.

Note: I have not used map_err due to downcasting and other checks.

I've changed the client library with braking changes. Let me know if it is ok.