### PR TITLE
Fix startup on brand new chain and catchup after long break.

### DIFF
--- a/src/tasks/index.rs
+++ b/src/tasks/index.rs
@@ -20,6 +20,8 @@ const TIME_BETWEEN_FEE_ESTIMATION_SECONDS: u64 = 30;
 
 const GAS_PRICE_FOR_METRICS_FACTOR: f64 = 1e-9;
 
+const MAX_RECENT_BLOCKS_TO_CHECK: u64 = 60;
+
 pub async fn index_chain(app: Arc<App>, chain_id: u64) -> eyre::Result<()> {
     loop {
         index_inner(app.clone(), chain_id).await?;
@@ -127,10 +129,8 @@ pub async fn backfill_to_block(
         // Because we do not store all the blocks (we clean up older blocks) there is no need
         // to scan ALL the blocks. Especially as this may take a lot of time... We are trying
         // here to move back in time "enough" to get some estimates later.
-        let jump_back_blocks = 60u64;
-
-        if latest_block_number > jump_back_blocks {
-            latest_block_number - jump_back_blocks
+        if latest_block_number > MAX_RECENT_BLOCKS_TO_CHECK {
+            latest_block_number - MAX_RECENT_BLOCKS_TO_CHECK
         } else {
             0
         }

--- a/src/tasks/prune.rs
+++ b/src/tasks/prune.rs
@@ -8,8 +8,8 @@ use crate::app::App;
 const BLOCK_PRUNING_INTERVAL: Duration = Duration::from_secs(60);
 const TX_PRUNING_INTERVAL: Duration = Duration::from_secs(60);
 
-const fn minutes(seconds: i64) -> i64 {
-    seconds * 60
+const fn minutes(minutes: i64) -> i64 {
+    minutes * 60
 }
 
 const fn hours(hours: i64) -> i64 {

--- a/src/tasks/prune.rs
+++ b/src/tasks/prune.rs
@@ -12,12 +12,12 @@ const fn minutes(seconds: i64) -> i64 {
     seconds * 60
 }
 
-const fn hours(seconds: i64) -> i64 {
-    minutes(seconds) * 60
+const fn hours(hours: i64) -> i64 {
+    minutes(hours) * 60
 }
 
-const fn days(seconds: i64) -> i64 {
-    hours(seconds) * 24
+const fn days(days: i64) -> i64 {
+    hours(days) * 24
 }
 
 // TODO: This should be a per network setting


### PR DESCRIPTION
Two things:
* on startup with brand new chain (tests for example) select proper starting block (0)
* when starting after long break (example is a fork of chain) get some blocks from the past to estimates fees