### PR TITLE
Escalation monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,32 @@
 An easy to run transaction relayer.
 
 ## Quickstart
+
 Copy `.env.example` to `.env` or set `RUST_LOG=info,service=debug` to have logging.
 
 1. Spin up the database `docker run --rm -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres`
 2. Spin up a chain `anvil --chain-id 31337 --block-time 2`
 3. Start the service `cargo run`
-4. Visit http://localhost:3000/swagger or http://localhost:3000/rapidoc to interact with the api. Redoc ui is also available at http://localhost:3000/redoc but it's not interactive.
+4. Visit <http://localhost:3000/swagger> or <http://localhost:3000/rapidoc> to interact with the api. Redoc ui is also available at <http://localhost:3000/redoc> but it's not interactive.
 
-API schema can be downloaded from http://localhost:3000/schema.json or http://localhost:3000/schema.yml
+API schema can be downloaded from <http://localhost:3000/schema.json> or <http://localhost:3000/schema.yml>
 
 This will use the `config.toml` configuration.
 
 ### Error reporting & debugging
+
 For a better local development experience the `.env.example` enables color-eyre reporting.
 
 But that by default doesn't include the backtrace or code snippets. In order to enable snippets run with `RUST_LIB_BACKTRACE=full`.
 
 ## Configuration
+
 The Tx Sitter can be configured in 2 ways:
+
 1. Using the config file, refer to `config.rs` and `config.toml` for more info
 2. Using env vars. Every field in the config can also be set via an env var.
    For example the following config
+
    ```toml
     [service]
     escalation_interval = "1m"
@@ -42,6 +47,7 @@ The Tx Sitter can be configured in 2 ways:
     ```
 
     Can also be expressed with env vars
+
     ```
     TX_SITTER__SERVICE__ESCALATION_INTERVAL="1m"
     TX_SITTER__SERVICE__MAX_ESCALATIONS="100"
@@ -52,21 +58,26 @@ The Tx Sitter can be configured in 2 ways:
     ```
 
 ## Running tests
+
 While you obviously can run tests with
+
 ```
 cargo test --workspace
 ```
+
 some tests take quite a long time (due to spinning up an anvil node, sending txs, etc.).
 
 Therefore I recommend [cargo-nextest](https://nexte.st/) as it runs all the tests in parallel. Once installed
+
 ```
 cargo nextest run --workspace
 ```
+
 can be used instead.
 
 ## Client
 
-Client crate is located in `creates/tx-sitter-client`. It is generated using official OpenAPI generator with modified template files. Modified template files are located in `client-template/` directory.  Possible files to overwrite could be fined here https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/rust.
+Client crate is located in `creates/tx-sitter-client`. It is generated using official OpenAPI generator with modified template files. Modified template files are located in `client-template/` directory.  Possible files to overwrite could be fined here <https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/rust>.
 
 ### Runnin script
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Tx Sitter can be configured in 2 ways:
     Can also be expressed with env vars
     ```
     TX_SITTER__SERVICE__ESCALATION_INTERVAL="1m"
+    TX_SITTER__SERVICE__MAX_ESCALATIONS="100"
     TX_SITTER__SERVER__HOST="127.0.0.1:3000"
     TX_SITTER__SERVER__DISABLE_AUTH="true"
     TX_SITTER__DATABASE__CONNECTION_STRING="postgres://postgres:postgres@127.0.0.1:5432/database"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,10 @@ pub struct TxSitterConfig {
     #[serde(with = "humantime_serde")]
     pub escalation_interval: Duration,
 
+    /// Maximum number of escalations of a given transaction
+    #[serde(default = "default::escalation_max_per_relayer")]
+    pub max_escalations: usize,
+
     #[serde(
         with = "humantime_serde",
         default = "default::soft_reorg_interval"
@@ -230,6 +234,10 @@ mod default {
         Duration::from_secs(60)
     }
 
+    pub fn max_escalations() -> usize {
+        100
+    }
+
     pub mod metrics {
         pub fn host() -> String {
             "127.0.0.1".to_string()
@@ -258,6 +266,7 @@ mod tests {
     const WITH_DB_CONNECTION_STRING: &str = indoc! {r#"
         [service]
         escalation_interval = "1h"
+        escalation_max_per_relayer = 100
         soft_reorg_interval = "1m"
         hard_reorg_interval = "1h"
         block_stream_timeout = "1m"
@@ -276,6 +285,7 @@ mod tests {
     const WITH_DB_PARTS: &str = indoc! {r#"
         [service]
         escalation_interval = "1h"
+        escalation_max_per_relayer = 100
         soft_reorg_interval = "1m"
         hard_reorg_interval = "1h"
         block_stream_timeout = "1m"
@@ -300,6 +310,7 @@ mod tests {
         let config = Config {
             service: TxSitterConfig {
                 escalation_interval: Duration::from_secs(60 * 60),
+                max_escalations: default::max_escalations(),
                 soft_reorg_interval: default::soft_reorg_interval(),
                 hard_reorg_interval: default::hard_reorg_interval(),
                 block_stream_timeout: default::block_stream_timeout(),
@@ -329,6 +340,7 @@ mod tests {
         let config = Config {
             service: TxSitterConfig {
                 escalation_interval: Duration::from_secs(60 * 60),
+                max_escalations: default::max_escalations(),
                 soft_reorg_interval: default::soft_reorg_interval(),
                 hard_reorg_interval: default::hard_reorg_interval(),
                 block_stream_timeout: default::block_stream_timeout(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ pub struct TxSitterConfig {
     pub escalation_interval: Duration,
 
     /// Maximum number of escalations of a given transaction
-    #[serde(default = "default::escalation_max_per_relayer")]
+    #[serde(default = "default::max_escalations")]
     pub max_escalations: usize,
 
     #[serde(
@@ -266,7 +266,7 @@ mod tests {
     const WITH_DB_CONNECTION_STRING: &str = indoc! {r#"
         [service]
         escalation_interval = "1h"
-        escalation_max_per_relayer = 100
+        max_escalations = 100
         soft_reorg_interval = "1m"
         hard_reorg_interval = "1h"
         block_stream_timeout = "1m"
@@ -285,7 +285,7 @@ mod tests {
     const WITH_DB_PARTS: &str = indoc! {r#"
         [service]
         escalation_interval = "1h"
-        escalation_max_per_relayer = 100
+        max_escalations = 100
         soft_reorg_interval = "1m"
         hard_reorg_interval = "1h"
         block_stream_timeout = "1m"

--- a/src/db.rs
+++ b/src/db.rs
@@ -811,6 +811,7 @@ impl Database {
     pub async fn get_txs_for_escalation(
         &self,
         escalation_interval: Duration,
+        max_escalations: usize,
     ) -> eyre::Result<Vec<TxForEscalation>> {
         Ok(sqlx::query_as(
             r#"
@@ -824,10 +825,12 @@ impl Database {
             WHERE  now() - h.created_at > $1
             AND    s.status = $2
             AND    NOT h.escalated
+            AND    s.escalation_count < $3
             "#,
         )
         .bind(escalation_interval)
         .bind(TxStatus::Pending)
+        .bind(max_escalations as i64)
         .fetch_all(&self.pool)
         .await?)
     }

--- a/src/tasks/escalate.rs
+++ b/src/tasks/escalate.rs
@@ -85,6 +85,17 @@ async fn escalate_relayer_tx(
         return Ok(());
     }
 
+    if tx.escalation_count > app.config.service.max_escalations {
+        tracing::warn!(
+            relayer_id = relayer.id,
+            tx_id = tx.id,
+            escalation_count = tx.escalation_count,
+            "Too many escalations"
+        );
+
+        return Ok(());
+    }
+
     tracing::info!(
         tx_id = tx.id,
         escalation_count = tx.escalation_count,

--- a/src/tasks/escalate.rs
+++ b/src/tasks/escalate.rs
@@ -97,15 +97,11 @@ async fn escalate_relayer_tx(
         .signer_middleware(tx.chain_id, tx.key_id.clone())
         .await?;
 
-    tracing::info!("Escalating transaction - got middleware");
-
     let fees = app
         .db
         .get_latest_block_fees_by_chain_id(tx.chain_id)
         .await?
         .context("Missing block")?;
-
-    tracing::info!("Escalating transaction - got block fees");
 
     // Min increase of 20% on the priority fee required for a replacement tx
     let factor = U256::from(100);
@@ -137,13 +133,9 @@ async fn escalate_relayer_tx(
         chain_id: Some(tx.chain_id.into()),
     };
 
-    tracing::info!("Escalating transaction - assembled tx");
-
     let pending_tx = middleware
         .send_transaction(TypedTransaction::Eip1559(eip1559_tx), None)
         .await;
-
-    tracing::info!("Escalating transaction - sent tx");
 
     let pending_tx = match pending_tx {
         Ok(pending_tx) => pending_tx,
@@ -152,8 +144,6 @@ async fn escalate_relayer_tx(
             return Ok(());
         }
     };
-
-    tracing::info!("Escalating transaction - got pending tx");
 
     let tx_hash = pending_tx.tx_hash();
 

--- a/tests/common/service_builder.rs
+++ b/tests/common/service_builder.rs
@@ -18,6 +18,7 @@ pub struct ServiceBuilder {
     escalation_interval: Duration,
     soft_reorg_interval: Duration,
     hard_reorg_interval: Duration,
+    max_escalations: usize,
 }
 
 impl Default for ServiceBuilder {
@@ -26,6 +27,7 @@ impl Default for ServiceBuilder {
             escalation_interval: Duration::from_secs(5),
             soft_reorg_interval: Duration::from_secs(10),
             hard_reorg_interval: Duration::from_secs(15),
+            max_escalations: 100,
         }
     }
 }
@@ -46,6 +48,11 @@ impl ServiceBuilder {
         self
     }
 
+    pub fn max_escalations(mut self, max: usize) -> Self {
+        self.max_escalations = max;
+        self
+    }
+
     pub async fn build(
         self,
         anvil: &AnvilInstance,
@@ -56,6 +63,7 @@ impl ServiceBuilder {
         let config = Config {
             service: TxSitterConfig {
                 escalation_interval: self.escalation_interval,
+                max_escalations: self.max_escalations,
                 soft_reorg_interval: self.soft_reorg_interval,
                 hard_reorg_interval: self.hard_reorg_interval,
                 block_stream_timeout: Duration::from_secs(60),


### PR DESCRIPTION
This PR adds a configuration param that controls the max number a tx can be escalated.

Exceeding this value will prevent further escalations & emit a warning log.
